### PR TITLE
[bugfix] Fix RangeStepper

### DIFF
--- a/stepper.go
+++ b/stepper.go
@@ -24,7 +24,7 @@ func (i *RangeStepper) Next() (float64, bool) {
 
 	value := i.current
 
-	i.current++
+	i.current += i.stepSize
 
 	return value, true
 }


### PR DESCRIPTION
Makes `RangeStepper` increment by the `stepSize` and not just by 1 every time.